### PR TITLE
Fix parser assignment direction and scope handling

### DIFF
--- a/src/org/ioopm/calculator/Calculator.java
+++ b/src/org/ioopm/calculator/Calculator.java
@@ -47,9 +47,7 @@ public class Calculator {
                         break;
                     }
                 } else {
-                    env.pushEnvironment();
                     if (!namedChecker.check(expr)) {
-                        env.popEnvironment();
                         System.out.println("Error, assignments to named constants:");
                         for (String illegal : namedChecker.getIllegalAssignments()) {
                             System.out.println("    " + illegal);
@@ -57,9 +55,7 @@ public class Calculator {
                         continue;
                     }
 
-                    env.pushEnvironment();
                     if (!reassignmentChecker.check(expr)) {
-                        env.popEnvironment();
                         System.out.println("Error, the following variables are reassigned:");
                         for (String variable : reassignmentChecker.getReassignedVariables()) {
                             System.out.println("    " + variable);
@@ -70,7 +66,6 @@ public class Calculator {
                     expressionsEntered++;
                     SymbolicExpression result = evaluator.evaluate(expr, env);
                     successfullyEvaluated++;
-                    env.popEnvironment();
 
                     if (result.isConstant()) {
                         fullyEvaluated++;

--- a/src/org/ioopm/calculator/parser/CalculatorParser.java
+++ b/src/org/ioopm/calculator/parser/CalculatorParser.java
@@ -115,27 +115,28 @@ public class CalculatorParser {
     private SymbolicExpression assignment() throws IOException {
         SymbolicExpression result = expression();
         this.st.nextToken();
-    
+
         while (this.st.ttype == '=') {
             this.st.nextToken();
-    
-            // Kontrollera att vänster sida är en giltig variabel
-            if (result instanceof NamedConstant) {
-                throw new RuntimeException("Error: Assignment to a named constant '" + result + "'");
-            }
-    
-            if (!(result instanceof Variable)) {
-                throw new SyntaxErrorException("Error: Left-hand side of assignment must be a variable");
-            }
-    
+
+            // Right-hand side should be an identifier representing the variable
             if (this.st.ttype == this.st.TT_NUMBER) {
                 throw new SyntaxErrorException("Error: Numbers cannot be used as variable names");
             } else if (this.st.ttype != this.st.TT_WORD) {
                 throw new SyntaxErrorException("Error: Invalid assignment syntax");
-            } else {
-                SymbolicExpression key = identifier();
-                result = new Assignment(result, key);
             }
+
+            SymbolicExpression key = identifier();
+
+            if (key instanceof NamedConstant) {
+                throw new RuntimeException("Error: Assignment to a named constant '" + key + "'");
+            }
+
+            if (!(key instanceof Variable)) {
+                throw new SyntaxErrorException("Error: Right-hand side of assignment must be a variable");
+            }
+
+            result = new Assignment(result, key);
             this.st.nextToken();
         }
     
@@ -325,7 +326,7 @@ public class CalculatorParser {
         }
     
         env.popEnvironment(); // Avsluta scopet
-        return new Sequence(expressions); // Returnera en sekvens av uttryck
+        return new Scope(new Sequence(expressions)); // Returnera ett Scope med en sekvens av uttryck
     }
     
     


### PR DESCRIPTION
## Summary
- corrected `CalculatorParser.assignment` to expect variables on the right-hand side
- fixed `scope()` in parser to produce a `Scope` node
- removed unnecessary environment pushes from main program

## Testing
- `make all`
- `printf '42 = x\nx\nQuit\n' | java -cp classes org.ioopm.calculator.Calculator`
- `printf '{1 = x} + {1 = x}\nQuit\n' | java -cp classes org.ioopm.calculator.Calculator`
- `make test` *(fails: Could not find or load main class org.ioopm.calculator.Test)*

------
https://chatgpt.com/codex/tasks/task_e_6841e0d97e588324a5787d16aef72a86