### PR TITLE
Fix scope parsing and prevent infinite loops

### DIFF
--- a/src/test/org/ioopm/calculator/parser/ParserTest.java
+++ b/src/test/org/ioopm/calculator/parser/ParserTest.java
@@ -215,4 +215,22 @@ public class ParserTest {
             }
         });
     }
+
+    /**
+     * Regression test for parsing a simple scope.
+     */
+    @Test
+    public void testParseSimpleScope() throws IOException {
+        SymbolicExpression result = parser.parse("{x}", new ScopedEnvironment());
+        assertTrue(result instanceof Scope);
+    }
+
+    /**
+     * Regression test ensuring scopes followed by expressions do not loop.
+     */
+    @Test
+    public void testParseScopeExpressionCombination() throws IOException {
+        SymbolicExpression result = parser.parse("{1 = x} + {x}", new ScopedEnvironment());
+        assertTrue(result instanceof Addition);
+    }
 }


### PR DESCRIPTION
## Summary
- correct look-ahead handling in `statement` so expressions start with the right token
- adjust `expression` and `term` to stop before `}` tokens
- improve `scope` to push back closing braces and detect unexpected EOF
- add regression tests for simple scopes

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f02f7f2c83249c021b6b51f60d71