### PR TITLE
Implement function call validation and named constants

### DIFF
--- a/src/org/ioopm/calculator/Calculator.java
+++ b/src/org/ioopm/calculator/Calculator.java
@@ -102,6 +102,8 @@ public class Calculator {
                 System.out.println("Error: " + e.getMessage());
             } catch (SyntaxErrorException e) {
                 System.out.println("Syntax Error: " + e.getMessage());
+            } catch (FunctionCallException e) {
+                System.out.println(e.getMessage());
             } catch (RuntimeException e) {
                 System.out.println("Unexpected Error: " + e.getMessage());
             }

--- a/src/org/ioopm/calculator/ast/EvaluationVisitor.java
+++ b/src/org/ioopm/calculator/ast/EvaluationVisitor.java
@@ -3,6 +3,7 @@ package org.ioopm.calculator.ast;
 import java.util.List;
 
 import org.ioopm.calculator.parser.IllegalAssignmentException;
+import org.ioopm.calculator.parser.FunctionCallException;
 
 public class EvaluationVisitor implements Visitor {
     private ScopedEnvironment env = null;
@@ -212,16 +213,16 @@ public class EvaluationVisitor implements Visitor {
     public SymbolicExpression visit(FunctionCall fc) {
         FunctionDeclaration func = env.getFunction(fc.getFunctionName());
         if (func == null) {
-            throw new RuntimeException("Error: Undefined function '" + fc.getFunctionName() + "'");
+            throw new FunctionCallException("Error, function '" + fc.getFunctionName() + "' is undefined.");
         }
 
         List<Variable> parameters = func.getParameters();
         List<SymbolicExpression> arguments = fc.getArguments();
 
-        if (parameters.size() != arguments.size()) {
-            throw new RuntimeException("Error: Function '" + fc.getFunctionName() +
-                    "' called with incorrect number of arguments. Expected " +
-                    parameters.size() + ", got " + arguments.size());
+        if (arguments.size() < parameters.size()) {
+            throw new FunctionCallException("Error, function '" + fc.getFunctionName() + "' called with too few arguments. Expected " + parameters.size() + ", got " + arguments.size() + ".");
+        } else if (arguments.size() > parameters.size()) {
+            throw new FunctionCallException("Error, function '" + fc.getFunctionName() + "' called with too many arguments. Expected " + parameters.size() + ", got " + arguments.size() + ".");
         }
 
         env.pushEnvironment();
@@ -248,11 +249,7 @@ public class EvaluationVisitor implements Visitor {
 
     @Override
     public SymbolicExpression visit(NamedConstant nc) {
-        if (env.containsKey(nc)) {
-            return env.get(nc);
-        } else {
-            throw new RuntimeException("Named constant '" + nc.getName() + "' is not defined");
-        }
+        return nc;
     }
 
 }

--- a/src/org/ioopm/calculator/parser/CalculatorParser.java
+++ b/src/org/ioopm/calculator/parser/CalculatorParser.java
@@ -224,29 +224,41 @@ public class CalculatorParser {
         return result;
     }
 
-    public SymbolicExpression functionCall() throws IOException{
+    public SymbolicExpression functionCall() throws IOException {
         String identifier = this.st.sval;
         this.st.nextToken();
         if (this.st.ttype != '(') {
             throw new SyntaxErrorException("Expected '(' after function name");
         }
-    
+
         List<SymbolicExpression> arguments = new ArrayList<>();
 
-        this.st.nextToken(); 
+        this.st.nextToken();
         while (this.st.ttype != ')') {
-            SymbolicExpression expr = expression(); 
-            arguments.add(expr);
+            SymbolicExpression arg;
+            if (this.st.ttype == this.st.TT_NUMBER) {
+                arg = new Constant(this.st.nval);
+            } else if (this.st.ttype == this.st.TT_WORD) {
+                if (Constants.namedConstants.containsKey(this.st.sval)) {
+                    arg = new NamedConstant(this.st.sval, Constants.namedConstants.get(this.st.sval));
+                } else {
+                    arg = new Variable(this.st.sval);
+                }
+            } else {
+                throw new SyntaxErrorException("Arguments to functions must be numbers or identifiers");
+            }
+
+            arguments.add(arg);
             this.st.nextToken();
             if (this.st.ttype == ',') {
-                this.st.nextToken(); 
+                this.st.nextToken();
             } else if (this.st.ttype == ')') {
                 break;
             } else {
                 throw new SyntaxErrorException("Expected ',' or ')' in parameter list");
             }
         }
-    
+
         return new FunctionCall(identifier, arguments);
     }
 

--- a/src/org/ioopm/calculator/parser/FunctionCallException.java
+++ b/src/org/ioopm/calculator/parser/FunctionCallException.java
@@ -1,0 +1,11 @@
+package org.ioopm.calculator.parser;
+
+/**
+ * Exception thrown when a function call is invalid, e.g. due to
+ * incorrect number of arguments or undefined functions.
+ */
+public class FunctionCallException extends RuntimeException {
+    public FunctionCallException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## Summary
- add `FunctionCallException` for clearer runtime errors when using functions
- validate argument counts in `EvaluationVisitor`
- restrict parser to only allow number or identifier arguments
- treat named constants as constants during evaluation
- surface function call errors directly in `Calculator`

## Testing
- `make all`
- manual functional checks of defining and calling functions with too few and too many arguments

------
https://chatgpt.com/codex/tasks/task_e_68500b7be9f48324bcb00952ce034f53